### PR TITLE
Finalize a bosh release task

### DIFF
--- a/finalize-bosh-release.sh
+++ b/finalize-bosh-release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e
+
+#
+# A little environment validation
+#
+if [ -z "$PRIVATE_YML_CONTENT" ]; then
+  echo "must specify \$PRIVATE_YML_CONTENT" >&2
+  exit 1
+fi
+
+cd release-git-repo
+RELEASE_NAME=`ls releases`
+
+tar -zxf ../final-builds-dir-tarball/final-builds-dir-${RELEASE_NAME}.tgz
+tar -zxf ../releases-dir-tarball/releases-dir-${RELEASE_NAME}.tgz
+cat <<EOF > "config/private.yml"
+$PRIVATE_YML_CONTENT
+EOF
+
+bosh -n create release --force --final --with-tarball
+
+mv releases/${RELEASE_NAME}/*.tgz ../finalized-release
+tar -czhf ../finalized-release/final-builds-dir-${RELEASE_NAME}.tgz .final_builds
+tar -czhf ../finalized-release/releases-dir-${RELEASE_NAME}.tgz releases

--- a/finalize-bosh-release.yml
+++ b/finalize-bosh-release.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+  - name: pipeline-tasks
+  - name: release-git-repo
+  - name: final-builds-dir-tarball
+  - name: releases-dir-tarball
+outputs:
+  - name: finalized-release
+run:
+  path: pipeline-tasks/finalize-bosh-release.sh
+
+params:
+  PRIVATE_YML:


### PR DESCRIPTION
@sharms @jezhumble 
This is a reusable task that we can use to do releases. 
Has 4 inputs:
- the pipeline tasks repo
- the repo of the bosh release itself
- a tarball of the `.final_builds` dir (which in a pipeline can come from S3)
- a tarball of the `releases` dir, where new release manifests are created (again, can come from S3)

Produces 3 outputs in a `finalized-release` dir:
- a tarball of the `.final_builds` dir (which in a pipeline can be pushed back to S3)
- a tarball of the `releases` dir, where new release yml are created (again, can go to S3)
- the final release tarball (again, can go to S3)

Example pipeline: https://github.com/18F/logsearch-for-cloudfoundry/commit/fa3d4f8ec988910ff2f5180c2a540114d967149a