### PR TITLE
Add a terraform get in case there are modules being used

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -33,6 +33,10 @@ terraform remote config \
   -backend-config="bucket=${S3_TFSTATE_BUCKET}" \
   -backend-config="key=${STACK_NAME}/terraform.tfstate"
 
+terraform get \
+  -update \
+  terraform-templates
+
 terraform apply \
   -refresh=true \
   terraform-templates

--- a/terraform-destroy.sh
+++ b/terraform-destroy.sh
@@ -33,8 +33,12 @@ terraform remote config \
   -backend-config="bucket=${S3_TFSTATE_BUCKET}" \
   -backend-config="key=${STACK_NAME}/terraform.tfstate"
 
+terraform get \
+  -update \
+  terraform-templates
+
 terraform destroy \
-    -refresh=true \
-    -force \
-    terraform-templates
+  -refresh=true \
+  -force \
+  terraform-templates
 


### PR DESCRIPTION
This allows us to use modules defined elsewhere (like for example, other repos) in terraform templates. 

See: 
- https://www.terraform.io/docs/modules/usage.html
- https://www.terraform.io/docs/commands/get.html