### PR TITLE
Add a single release upload task

### DIFF
--- a/upload-release.sh
+++ b/upload-release.sh
@@ -1,50 +1,26 @@
 #!/bin/bash
-# vim: set ft=sh
 
 set -e
 
-#
-# A little environment validation
-#
-if [ -z "$BOSH_CACERT" ]; then
-  echo "must specify \$BOSH_CACERT" >&2
-  exit 1
-fi
 if [ -z "$BOSH_TARGET" ]; then
   echo "must specify \$BOSH_TARGET" >&2
   exit 1
 fi
+
 if [ -z "$BOSH_USERNAME" ]; then
   echo "must specify \$BOSH_USERNAME" >&2
   exit 1
 fi
+
 if [ -z "$BOSH_PASSWORD" ]; then
   echo "must specify \$BOSH_PASSWORD" >&2
   exit 1
 fi
-if [ -z "$RELEASE_URL_FILE" ]; then
-  echo "must specify \$RELEASE_URL_FILE" >&2
-  exit 1
-fi
-if [ -z "$RELEASE_NAME" ]; then
-  echo "must specify \$RELEASE_NAME" >&2
-  exit 1
-fi
-if [ -z "$RELEASE_VERSION_FILE" ]; then
-  echo "must specify \$RELEASE_VERSION_FILE" >&2
-  exit 1
-fi
 
-#
-# Target BOSH
-#
-echo "Uploading $RELEASE_NAME @ `cat $RELEASE_VERSION_FILE`: `cat $RELEASE_URL_FILE`"
-cat <<EOF > rootca.pem
-$BOSH_CACERT
-EOF
-bosh --ca-cert rootca.pem -n target $BOSH_TARGET
-bosh login <<EOF 1>/dev/null
-$BOSH_USERNAME
-$BOSH_PASSWORD
-EOF
-bosh -n upload release `cat $RELEASE_URL_FILE` --name $RELEASE_NAME --version `cat $RELEASE_VERSION_FILE`
+bosh --ca-cert certificate/boshCA.crt -n target $BOSH_TARGET
+
+bosh login $BOSH_USERNAME $BOSH_PASSWORD
+
+for r in release/*.tgz; do
+	bosh upload release $r
+done

--- a/upload-release.yml
+++ b/upload-release.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: 18fgsa/concourse-task
+
+inputs:
+  - name: pipeline-tasks
+  - name: release
+  - name: certificate
+run:
+  path: pipeline-tasks/upload-release.sh
+
+params:
+  BOSH_USERNAME:
+  BOSH_PASSWORD:
+  BOSH_TARGET:


### PR DESCRIPTION
There was an existing `upload-release.sh` in this repo, but it had no corresponding task configuration.

This PR, simplifies the `upload-release.sh` script, and adds the `upload-release.yml`

This is in support of 18F/cg-atlas#57

