### PR TITLE
Add script to register service brokers.

### DIFF
--- a/register-service-broker.sh
+++ b/register-service-broker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -u
+
+# Authenticate
+cf login -a $CF_API_URL -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION -s $CF_SPACE
+
+# Get service broker URL
+BROKER_URL=https://$(cf app $BROKER_NAME | grep urls: | sed 's/urls: //')
+
+# Create or update service broker
+if ! cf create-service-broker $BROKER_NAME $AUTH_USER $AUTH_PASS $BROKER_URL; then
+  cf update-service-broker $BROKER_NAME $AUTH_USER $AUTH_PASS $BROKER_URL
+fi
+
+# Enable access to service plans
+ARGS=()
+if [ -n "$SERVICE_ORGANIZATION" ]; ARGS+=("-o", "$SERVICE_ORGANIZATION"); fi
+if [ -n "$SERVICE_PLAN" ]; ARGS+=("-p", "$SERVICE_PLAN"); fi
+for SERVICE_NAME in $(echo $SERVICE_NAMES); do
+  cf enable-service-access $SERVICE_NAME "${ARGS[@]}"
+done

--- a/register-service-broker.yml
+++ b/register-service-broker.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+
+inputs:
+- name: pipeline-tasks
+
+run:
+  path: pipeline-tasks/register-service-broker.sh


### PR DESCRIPTION
This has been copied and pasted enough that it's probably time to extract into its own script. Note--we could also use https://github.com/cloudfoundry-community/broker-registrar-boshrelease, but I think that's sort of overkill (and unnecessary indirection) for something as simple as this. What do you think @LinuxBozo?