### PR TITLE
Update tasks to use bosh cli v2.

### DIFF
--- a/bosh-errand.sh
+++ b/bosh-errand.sh
@@ -1,43 +1,14 @@
 #!/bin/bash
 # vim: set ft=sh
 
-set -e
+set -e -u
 
-#
-# A little environment validation
-#
-if [ -z "$BOSH_TARGET" ]; then
-  echo "must specify \$BOSH_TARGET" >&2
-  exit 1
-fi
-if [ -z "$BOSH_USERNAME" ]; then
-  echo "must specify \$BOSH_USERNAME" >&2
-  exit 1
-fi
-if [ -z "$BOSH_PASSWORD" ]; then
-  echo "must specify \$BOSH_PASSWORD" >&2
-  exit 1
-fi
-if [ -z "$BOSH_DEPLOYMENT_NAME" ]; then
-  echo "must specify \$BOSH_DEPLOYMENT_NAME" >&2
-  exit 1
-fi
-if [ -z "$BOSH_ERRAND" ]; then
-  echo "must specify \$BOSH_ERRAND" >&2
-  exit 1
-fi
-if [ -z "$BOSH_CACERT" ]; then
-  echo "must specify \$BOSH_CACERT" >&2
-  exit 1
-fi
 #
 # Run the errand for the appropriate deployment
 #
-bosh --ca-cert $BOSH_CACERT -n target $BOSH_TARGET
-bosh login <<EOF 1>/dev/null
-$BOSH_USERNAME
-$BOSH_PASSWORD
+bosh-cli -n -e ${BOSH_TARGET} --ca-cert ${BOSH_CACERT} alias-env env
+bosh-cli -e env log-in <<EOF 1>/dev/null
+${BOSH_USERNAME}
+${BOSH_PASSWORD}
 EOF
-bosh -n download manifest $BOSH_DEPLOYMENT_NAME ${BOSH_DEPLOYMENT_NAME}.yml
-bosh -n deployment ${BOSH_DEPLOYMENT_NAME}.yml
-bosh -n run errand $BOSH_ERRAND
+bosh-cli -n -e env -d ${BOSH_DEPLOYMENT_NAME} run-errand ${BOSH_ERRAND}

--- a/finalize-bosh-release.sh
+++ b/finalize-bosh-release.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 # vim: set ft=sh
 
-set -e
-
-#
-# A little environment validation
-#
-if [ -z "$PRIVATE_YML_CONTENT" ]; then
-  echo "must specify \$PRIVATE_YML_CONTENT" >&2
-  exit 1
-fi
+set -e -u
 
 cd release-git-repo
 RELEASE_NAME=`ls releases`
@@ -26,7 +18,7 @@ $FINAL_YML_CONTENT
 EOF
 fi
 
-bosh -n create release --force --final --with-tarball
+bosh-cli -n create-release --force --final --tarball
 
 mv releases/${RELEASE_NAME}/*.tgz ../finalized-release
 tar -czhf ../finalized-release/final-builds-dir-${RELEASE_NAME}.tgz .final_builds


### PR DESCRIPTION
Context: we're now installing the new bosh cli as `bosh-cli` in https://github.com/18F/cg-deploy-concourse-docker-image/pull/12.