### PR TITLE
Add CF_FLAGS for register-service-broker

### DIFF
--- a/register-service-broker.sh
+++ b/register-service-broker.sh
@@ -10,7 +10,7 @@ cf login -a $CF_API_URL -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION -s $
 BROKER_URL=https://$(cf app $BROKER_NAME | grep urls: | sed 's/urls: //')
 
 # Create or update service broker
-if ! cf create-service-broker $BROKER_NAME $AUTH_USER $AUTH_PASS $BROKER_URL; then
+if ! cf create-service-broker $BROKER_NAME $AUTH_USER $AUTH_PASS $BROKER_URL $CF_FLAGS; then
   cf update-service-broker $BROKER_NAME $AUTH_USER $AUTH_PASS $BROKER_URL
 fi
 

--- a/register-service-broker.yml
+++ b/register-service-broker.yml
@@ -6,6 +6,10 @@ image_resource:
   source:
     repository: 18fgsa/concourse-task
 
+# Optional flags to pass to the `create-service-broker`, blank by default
+params:
+  CF_FLAGS:
+
 inputs:
 - name: pipeline-tasks
 


### PR DESCRIPTION
This is needed for the work on `cg-deploy-uaa-guard-broker` to enable `--space-scoped` when registering a new service broker.

18F/cg-deploy-uaa-guard-broker#1

cc: @linuxbozo @rememberlenny