### PR TITLE
Handle empty bosh errand flags.

### DIFF
--- a/bosh-errand.sh
+++ b/bosh-errand.sh
@@ -18,4 +18,6 @@ ${BOSH_PASSWORD}
 EOF
 fi
 
-bosh-cli -n -e env -d "${BOSH_DEPLOYMENT_NAME}" run-errand "${BOSH_ERRAND}" "${BOSH_FLAGS:-}"
+args=("${BOSH_ERRAND}")
+args+=(${BOSH_FLAGS:-})
+bosh-cli -n -e env -d "${BOSH_DEPLOYMENT_NAME}" run-errand "${args[@]}"


### PR DESCRIPTION
So that bosh-cli doesn't get mad when `BOSH_FLAGS` is empty.