### PR TITLE
Update for terraform 0.9.x.

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -21,11 +21,6 @@ if [ -n "${TEMPLATE_SUBDIR:-}" ]; then
   DIR="$DIR/$TEMPLATE_SUBDIR"
 fi
 
-${TERRAFORM} remote config \
-  -backend=s3 \
-  -backend-config="encrypt=true" \
-  -backend-config="bucket=${S3_TFSTATE_BUCKET}" \
-  -backend-config="key=${STACK_NAME}/terraform.tfstate" || \
 ${TERRAFORM} init \
   -backend=true \
   -backend-config="encrypt=true" \

--- a/terraform-apply.yml
+++ b/terraform-apply.yml
@@ -8,6 +8,7 @@ image_resource:
 inputs:
 - name: pipeline-tasks
 - name: terraform-templates
+
 outputs:
 - name: terraform-state
 
@@ -18,6 +19,4 @@ params:
   STACK_NAME:
   TEMPLATE_SUBDIR:
   S3_TFSTATE_BUCKET:
-  AWS_ACCESS_KEY_ID:
-  AWS_SECRET_ACCESS_KEY:
   AWS_DEFAULT_REGION:

--- a/terraform-state-to-yaml.yml
+++ b/terraform-state-to-yaml.yml
@@ -10,6 +10,7 @@ inputs:
 - name: terraform-state
 outputs:
 - name: terraform-yaml
+
 run:
   path: pipeline-tasks/terraform-state-to-yaml.sh
 


### PR DESCRIPTION
Goes with https://github.com/18F/cg-deploy-concourse-docker-image/pull/25.