### PR TITLE
Update how we get the release name (and some shellcheck fixes)

### DIFF
--- a/finalize-bosh-release.sh
+++ b/finalize-bosh-release.sh
@@ -4,10 +4,10 @@
 set -e -u
 
 cd release-git-repo
-RELEASE_NAME=`ls releases`
+RELEASE_NAME=$(grep final_name config/final.yml | awk '{print $2}')
 
-tar -zxf ../final-builds-dir-tarball/final-builds-dir-${RELEASE_NAME}.tgz
-tar -zxf ../releases-dir-tarball/releases-dir-${RELEASE_NAME}.tgz
+tar -zxf "../final-builds-dir-tarball/final-builds-dir-${RELEASE_NAME}.tgz"
+tar -zxf "../releases-dir-tarball/releases-dir-${RELEASE_NAME}.tgz"
 cat <<EOF > "config/private.yml"
 $PRIVATE_YML_CONTENT
 EOF
@@ -18,9 +18,9 @@ $FINAL_YML_CONTENT
 EOF
 fi
 
-bosh-cli -n create-release --force --final --tarball=./${RELEASE_NAME}.tgz
-latest_release=$(ls releases/${RELEASE_NAME}/${RELEASE_NAME}*.yml | grep -oe '[0-9.]\+.yml' | sed -e 's/\.yml$//' | sort -V | tail -1)
-mv ${RELEASE_NAME}.tgz ../finalized-release/${RELEASE_NAME}-${latest_release}.tgz
+bosh-cli -n create-release --force --final --tarball="./${RELEASE_NAME}.tgz"
+latest_release=$(ls "releases/${RELEASE_NAME}/${RELEASE_NAME}*.yml" | grep -oe '[0-9.]\+.yml' | sed -e 's/\.yml$//' | sort -V | tail -1)
+mv "${RELEASE_NAME}.tgz" "../finalized-release/${RELEASE_NAME}-${latest_release}.tgz"
 
-tar -czhf ../finalized-release/final-builds-dir-${RELEASE_NAME}.tgz .final_builds
-tar -czhf ../finalized-release/releases-dir-${RELEASE_NAME}.tgz releases
+tar -czhf "../finalized-release/final-builds-dir-${RELEASE_NAME}.tgz" .final_builds
+tar -czhf "../finalized-release/releases-dir-${RELEASE_NAME}.tgz" releases


### PR DESCRIPTION
Relates to https://github.com/18F/cg-deploy-bosh/pull/270 so we can use upstream release as-is