### PR TITLE
Overwrite existing release metadata.

### DIFF
--- a/finalize-bosh-release.sh
+++ b/finalize-bosh-release.sh
@@ -6,6 +6,10 @@ set -e -u
 cd release-git-repo
 RELEASE_NAME=$(grep final_name config/final.yml | awk '{print $2}')
 
+# Clear existing release metadata to avoid conflicts with upstream
+rm releases/${RELEASE_NAME}/*.yml
+rm -rf .final_builds
+
 tar -zxf "../final-builds-dir-tarball/final-builds-dir-${RELEASE_NAME}.tgz"
 tar -zxf "../releases-dir-tarball/releases-dir-${RELEASE_NAME}.tgz"
 cat <<EOF > "config/private.yml"


### PR DESCRIPTION
Avoids conflicts with upstream releases whose metadata doesn't exist in
our blobstores.