### PR TITLE
Add necessary params

### DIFF
--- a/register-service-broker.yml
+++ b/register-service-broker.yml
@@ -11,3 +11,14 @@ inputs:
 
 run:
   path: pipeline-tasks/register-service-broker.sh
+
+params:
+  CF_API_URL:
+  CF_USERNAME:
+  CF_PASSWORD:
+  CF_ORGANIZATION:
+  CF_SPACE:
+  BROKER_NAME:
+  AUTH_USER:
+  AUTH_PASS:
+  SERVICES:

--- a/terraform-apply.yml
+++ b/terraform-apply.yml
@@ -14,3 +14,19 @@ outputs:
 
 run:
   path: pipeline-tasks/terraform-apply.sh
+
+params:
+  TERRAFORM_ACTION:
+  STACK_NAME:
+  TEMPLATE_SUBDIR:
+  S3_TFSTATE_BUCKET:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
+  AWS_DEFAULT_REGION:
+  TF_VAR_stack_description:
+  TF_VAR_aws_default_region:
+  TF_VAR_cdn_broker_username:
+  TF_VAR_cdn_broker_bucket:
+  TF_VAR_cdn_broker_cloudfront_prefix:
+  TF_VAR_cdn_broker_hosted_zone:
+  TF_VAR_lets_encrypt_hosted_zone:


### PR DESCRIPTION
This behavior has been deprecated since 4.1.0 and will eventually cause an error in later Concourse versions.
https://concourse-ci.org/download.html#v410

Keeping this [wip] for now as these task files are used throughout Concourse pipelines.