### PR TITLE
Blacklist sandbox orgs basic plans

### DIFF
--- a/register-service-broker.sh
+++ b/register-service-broker.sh
@@ -11,7 +11,7 @@ while getopts ":s" opt; do
   case $opt in
     s)
       ORGLIST=""
-      for org in $(cf orgs | grep sandbox); do
+      for org in $(cf orgs | grep 'sandbox\|SMOKE\|CATS\|test'); do
         ORGLIST+=${org}" "
       done      
       export SERVICE_ORGANIZATION_BLACKLIST=${ORGLIST}

--- a/register-service-broker.sh
+++ b/register-service-broker.sh
@@ -13,9 +13,8 @@ while getopts ":s" opt; do
       ORGLIST=""
       for org in $(cf orgs | grep sandbox); do
         ORGLIST+=${org}" "
-      done
-      ORGLIST+="cloud-gov"
-      export SERVICE_ORGANIZATION=${ORGLIST}
+      done      
+      export SERVICE_ORGANIZATION_BLACKLIST=${ORGLIST}
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2


### PR DESCRIPTION
Turned out the access wasn't quite set right.  This limits sandbox plans to _only_ be able to see the sandbox s3 plans.  So we don't have to worry about this anymore on interrupt.   If you do merge, merge this PR first before this one: https://github.com/18F/cg-deploy-s3-broker/pull/24 .