### PR TITLE
Unset empty TF_VAR_* variables

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -13,6 +13,13 @@ TERRAFORM="${TERRAFORM_BIN:-terraform}"
 
 DIR="terraform-templates"
 
+# unset TF_VARs that are empty strings
+for tfvar in "${!TF_VAR_@}"; do
+	if [[ -z "${!tfvar}" ]]; then
+		unset ${tfvar}
+	fi
+done
+
 if [ -n "${TEMPLATE_SUBDIR:-}" ]; then
   DIR="${DIR}/${TEMPLATE_SUBDIR}"
 fi


### PR DESCRIPTION
Either concourse or terraform started handling empty variables
differently, so defaults are being ignored in favor of empty strings
This unsets any empty variables that start with TF_VAR_