### PR TITLE
reverting 6ded59b.

### DIFF
--- a/finalize-bosh-release.sh
+++ b/finalize-bosh-release.sh
@@ -6,10 +6,6 @@ set -e -u
 cd release-git-repo
 RELEASE_NAME=$(grep final_name config/final.yml | awk '{print $2}')
 
-# Clear existing release metadata to avoid conflicts with upstream
-rm -f releases/"${RELEASE_NAME}"/*.yml
-rm -rf .final_builds
-
 tar -zxf "../final-builds-dir-tarball/final-builds-dir-${RELEASE_NAME}.tgz"
 tar -zxf "../releases-dir-tarball/releases-dir-${RELEASE_NAME}.tgz"
 cat <<EOF > "config/private.yml"


### PR DESCRIPTION
by removing the `.final_builds/` folder, it's removing all references to
vendored packages, new packages, etc. those references are needed and
nothing we do will affect upstream packages as we are using a custom
blobstore to store our custom-built releases.

[the build](https://ci.fr.cloud.gov/teams/main/pipelines/bosh-releases/jobs/build-logsearch-for-cloudfoundry-release/builds/52) was broken, but this fixes it.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>