### PR TITLE
Show terraform plan as it is executed instead of at end

### DIFF
--- a/terraform-apply.sh
+++ b/terraform-apply.sh
@@ -55,10 +55,8 @@ if [ "${TERRAFORM_ACTION}" = "plan" ]; then
     -refresh=true \
     -input=false \
     -out=${BASE}/terraform-state/terraform.tfplan \
-    > ${BASE}/terraform-state/terraform-plan-output.txt
-  
-  cat ${BASE}/terraform-state/terraform-plan-output.txt | \
-    grep -v --line-buffered --extended-regexp "Reading\.\.\.|Read complete after|Refreshing state\.\.\."
+    | tee ${BASE}/terraform-state/terraform-plan-output.txt \
+    | grep -v --line-buffered --extended-regexp "Reading\.\.\.|Read complete after|Refreshing state\.\.\."
 
   # Write a sentinel value; pipelines can alert to slack if set using `text_file`
   # Ensure that slack notification resource detects text file


### PR DESCRIPTION
## Changes proposed in this pull request:

- It's useful to see CLI output continuously instead of at the end of the (possibly long) `plan` process.
- Testing this out before giving `apply` the same treatment.
- Tested locally by running `while :; do echo "abc"; echo "def"; sleep 1; done | tee whileout | grep --line-buffered -e abc`, observing that only `abc` was repeatedly printed to the terminal, and confirming that both `abc` and `def` were written repeatedly to `whileout`. 
- Follow-up to 4ca1818e5dcd3aa31e78a5c05ec942e5cb5b405b and 7b45c8a2238ffb6dc5fab140fdd1a34304bc2909. 

## security considerations
None.