### PR TITLE
Fix encoding issues when processing Terraform state

### DIFF
--- a/terraform12-state-to-yaml.rb
+++ b/terraform12-state-to-yaml.rb
@@ -6,7 +6,7 @@ require 'yaml'
 # Ensure stdin containing Terraform state is treated as UTF-8, which addresses
 # issues with the json gem when the US-ASCII is set as the environment language
 # See https://github.com/ruby/json/issues/697#issuecomment-2807524053
-STDIN.set_encoding("UTF-8")
+$stdin.set_encoding("UTF-8")
 
 outputs = JSON.load($stdin)
 

--- a/terraform12-state-to-yaml.rb
+++ b/terraform12-state-to-yaml.rb
@@ -3,6 +3,11 @@
 require 'json'
 require 'yaml'
 
+# Ensure stdin containing Terraform state is treated as UTF-8, which addresses
+# issues with the json gem when the US-ASCII is set as the environment language
+# See https://github.com/ruby/json/issues/697#issuecomment-2807524053
+STDIN.set_encoding("UTF-8")
+
 outputs = JSON.load($stdin)
 
 terraform_outputs = { 'terraform_outputs' => {} }


### PR DESCRIPTION
## Changes proposed in this pull request:

- update Ruby script to treat stdin containing Terraform state as UTF-8 to fix encoding issues

## security considerations

None. The code is public. Treating input from the Terraform state as UTF-8 should be safe, since that is its expected format